### PR TITLE
Add public resources vendor directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/vendor/
 composer.lock
 Tests/Resources/app/cache
 Tests/Resources/app/logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-vendor/
 Resources/public/vendor/create
 Resources/public/vendor/hallo
 Resources/public/vendor/ckeditor

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-Resources/public/vendor/create
-Resources/public/vendor/hallo
-Resources/public/vendor/ckeditor
 composer.lock
 Tests/Resources/app/cache
 Tests/Resources/app/logs

--- a/src/Resources/public/vendor/.gitignore
+++ b/src/Resources/public/vendor/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This directory must be versionned to allow assets
install within ScriptHandler::gitSynchronize().

Otherwize, [call to chdir() function](https://github.com/symfony-cmf/create-bundle/blob/faade364ca52379c2583c0583c804455fb66d54e/src/Composer/ScriptHandler.php#L108) fail due to nonexistant _vendor_ directory. 